### PR TITLE
articles/30d93ed7ea1a5e.mdにおいて、Cookie, LocalStorageのセット状況テーブルが反映されていなかったので修正

### DIFF
--- a/articles/30d93ed7ea1a5e.md
+++ b/articles/30d93ed7ea1a5e.md
@@ -26,7 +26,7 @@ YouTubeのプライバシー強化モードとは、YouTube動画を埋め込む
 実際にHTML上でiframeを使ってYouTube動画を埋め込んだ際に、`youtube.com`と`youtube-nocookie.com`で、CookieとLocalStorageがどのようにセットされるかを調べた。
 
 | TYPE | 名前 | ドメイン | 目的 | youtube | youtube-nocookie |
-| ---- | -------- | ------- | -- | -- | -- | --|
+| ---- | -------- | ------- | --- | --- | --- |
 | Cookie | VISITOR_INFO1_LIVE | .youtube.com | 機能,広告 | セットされる | **セットされない** |
 | Cookie | YSC | .youtube.com | 機能 | セットされる | **セットされない** |
 | Cookie | IDE | .doubleclick.net | 広告 | セットされる | **セットされない** |


### PR DESCRIPTION
[YouTube動画をyoutube-nocookie.comで埋め込むと何が変わるのか](https://zenn.dev/pekeq/articles/30d93ed7ea1a5e)において、markdownのテーブルがうまく反映されていなかったので修正しました。